### PR TITLE
Fix void returns (as from ,enter).

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1568,6 +1568,8 @@
                     (make-num expr)]
                    [(string? (syntax-e expr))
                     (make-str expr)]
+                   [(eq? (void) (syntax-e expr))
+                    (void)]
                    [else
                     (raise-syntax-error #f
                                         "don't know how to typecheck"


### PR DESCRIPTION
This fixes Geiser's C-c C-a command which does `,enter "foo.rkt"` which seems to return void, which fails the typecheck.

I'm not 100% sure this is the right way to fix the issue, but it works in my tests.
