### PR TITLE
add support for type-annotations in define-values

### DIFF
--- a/plai-typed/tests/basic.rkt
+++ b/plai-typed/tests/basic.rkt
@@ -380,3 +380,11 @@
 (define (build-hash classhash)
  (hash-set classhash '(something) 'another))
 (test (some 'another) (hash-ref (build-hash (hash (list))) '(something)))
+
+;; does define-values work correctly?
+(define-values (aoeua aoeub) (values 3 "banana"))
+(test 3 aoeua)
+(test "banana" aoeub)
+(define-values ([aoeuc : number] [aoeud : string]) (values 4 "plum"))
+(test 4 aoeuc)
+(test "plum" aoeud)

--- a/plai-typed/tests/synerror.rkt
+++ b/plai-typed/tests/synerror.rkt
@@ -140,3 +140,18 @@
  '(module m plai-typed
     (has-type 1 : symbol))
  #rx"number vs symbol|symbol vs number")
+
+(syn-test
+ '(module m plai-typed
+    (define (->) 3))
+ #rx"cannot redefine a keyword")
+
+(syn-test
+ '(module m plai-typed
+    (define-values (z ->) 3))
+ #rx"cannot redefine a keyword")
+
+(syn-test
+ '(module m plai-typed
+    (define-values (z [-> : number]) 3))
+ #rx"cannot redefine a keyword")


### PR DESCRIPTION
Based on the docs, it looks like the

(define-values ([a : number] [b : number]) (values 3 4))

...should work correctly. Currently, though, it doesn't; it looks like it just wasn't implemented. I believe this pull request adds tests and fixes the problem.

(Problem reported by @iondune )
