### PR TITLE
Fix misspelling in error message for `define-values`

### DIFF
--- a/plai-typed/main.rkt
+++ b/plai-typed/main.rkt
@@ -776,7 +776,7 @@
                       [(define-values: . _) 'ok]
                       [else (raise-syntax-error
                              #f
-                             "expected a function, constant, or tuple defininition"
+                             "expected a function, constant, or tuple definition"
                              thing)]))
                   (syntax->list #'(thing ...)))]))))
 


### PR DESCRIPTION
_Definition_ had one too many "in"s.