### PR TITLE
Add append to documentation

### DIFF
--- a/plai-typed/plai-typed.scrbl
+++ b/plai-typed/plai-typed.scrbl
@@ -350,6 +350,7 @@ by @scheme[expr] and calls @scheme[handle-expr].}
 @defthing[fourth ((listof 'a) -> 'a)]
 @defthing[list-ref ((listof 'a) number -> 'a)]
 @defthing[length ((listof 'a) -> number)]
+@defthing[append ((listof 'a) (listof 'a) -> (listof 'a))]
 @defthing[reverse ((listof 'a) -> (listof 'a))]
 @defthing[member ('a (listof 'a) -> boolean)]
 @defthing[map (('a -> 'b) (listof 'a) -> (listof 'b))]


### PR DESCRIPTION
It's `provide`d but not documented. In [the racket/base docs](file:///home/wchargin/racket/doc/reference/pairs.html?q=append#%28def._%28%28quote._~23~25kernel%29._append%29%29), `append` comes right before `reverse`, so I put it there here, too.

warning: I haven't tested this change because I don't know how to compile this repo. It looks pretty safe to me, though.